### PR TITLE
config: Add Ultimaker UltiMainboard v2 config.

### DIFF
--- a/config/generic-ultimaker-ultimainboard-v2.cfg
+++ b/config/generic-ultimaker-ultimainboard-v2.cfg
@@ -1,0 +1,123 @@
+# This file contains common pin mappings for Ultimaker UltiMainboard v2
+# boards. To use this config, the firmware should be compiled for the
+# AVR atmega2560.
+
+# See the example.cfg file for a description of available parameters.
+
+[stepper_x]
+step_pin: ar25
+dir_pin: !ar23
+enable_pin: !ar27
+step_distance: .0125
+endstop_pin: ^!ar22
+position_endstop: 0
+position_max: 230
+homing_speed: 50.0
+
+[stepper_y]
+step_pin: ar32
+dir_pin: ar33
+enable_pin: !ar31
+step_distance: .0125
+endstop_pin: ^!ar26
+position_endstop: 225
+position_max: 225
+homing_speed: 50.0
+
+[stepper_z]
+step_pin: ar35
+dir_pin: !ar36
+enable_pin: !ar34
+step_distance: .005
+endstop_pin: ^!ar29
+position_endstop: 215
+position_max: 215
+homing_speed: 20.0
+
+[extruder]
+step_pin: ar42
+dir_pin: ar43
+enable_pin: !ar37
+step_distance: .003546
+nozzle_diameter: 0.400
+filament_diameter: 2.850
+heater_pin: ar2
+sensor_type: PT100 INA826
+sensor_pin: analog8
+control: pid
+pid_Kp: 22.2
+pid_Ki: 1.08
+pid_Kd: 114
+min_temp: 0
+max_temp: 275
+
+# Dual extruder support.
+#[extruder1]
+#step_pin: ar49
+#dir_pin: ar47
+#enable_pin: !ar48
+#step_distance: .003546
+#nozzle_diameter: 0.400
+#filament_diameter: 2.850
+#heater_pin: ar3
+#sensor_type: PT100 INA826
+#sensor_pin: analog9
+#control: pid
+#pid_Kp: 22.2
+#pid_Ki: 1.08
+#pid_Kd: 114
+#min_temp: 0
+#max_temp: 275
+
+[heater_bed]
+heater_pin: ar4
+sensor_type: PT100 INA826
+sensor_pin: analog10
+control: watermark
+min_temp: 0
+max_temp: 100
+
+[fan]
+pin: ar7
+
+[mcu]
+serial: /dev/ttyACM0
+pin_map: arduino
+
+[printer]
+kinematics: cartesian
+max_velocity: 500
+max_accel: 3000
+max_z_velocity: 25
+max_z_accel: 30
+
+[output_pin case_light]
+pin: ar8
+static_value: 1.0
+
+# Motor current settings.
+[output_pin stepper_xy_current]
+pin: ar44
+pwm: True
+scale: 1.5
+# Max power setting.
+cycle_time: .000030
+hardware_pwm: True
+static_value: 1.200
+# Power adjustment setting.
+
+[output_pin stepper_z_current]
+pin: ar45
+pwm: True
+scale: 1.5
+cycle_time: .000030
+hardware_pwm: True
+static_value: 1.200
+
+[output_pin stepper_e_current]
+pin: ar46
+pwm: True
+scale: 1.5
+cycle_time: .000030
+hardware_pwm: True
+static_value: 1.250


### PR DESCRIPTION
Adds config for the Ultimaker 2's UltiMainboard v2 board, with the 
correct pins assigned and current control for the A4988 motor
drivers.

Signed-off-by: Avery Todd <averyct@pm.me>